### PR TITLE
Drop the node.loggly.token.from_databag attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By default, this cookbook depends on the use of **encrypted data bags** to store
 }
 ```
 You may change the name of the data bag and item via the `node['loggly']['token']['databag']` and `node['loggly']['token']['databag_item']` attributes respectively.
-Also, if you do not want this cookbook to load the credentials for you, and instead want to set them yourself, set `node['loggly']['token']['from_databag']` to `false`, and then set the credentials via `node['loggly']['token']['value']`.
+Also, if you do not want this cookbook to load the credentials for you, and instead want to set them yourself, then set the credentials via `node['loggly']['token']['value']`.
 
 
 Attributes
@@ -57,10 +57,9 @@ of a hash used to describe a file to monitor.
 * `node['loggly']['tls']['intermediate_cert_url']` - Url to the intermediate certificate
 * `node['loggly']['tls']['intermediate_cert_checksum']` - Checksum of the intermediate certificate
 
-* `default['loggly']['token']['from_databag']` - Whether to load the Loggly token from a Data Bag (defaults to true)
 * `default['loggly']['token']['databag']` - The name of the Data Bag to load the credentials from (defaults to "loggly")
 * `default['loggly']['token']['databag_item']` - The name of the Data Bag Item to load the credentials from (defaults to "token")
-* `default['loggly']['token']['value']` - The Loggly token. Set from the Data Bag above by default.
+* `default['loggly']['token']['value']` - The Loggly token to use instead of searching the databag (defaults to nil)
 
 * `node['loggly']['rsyslog']['conf']` - Name of the loggly rsyslog confiugration file (defaults to /etc/rsyslog.d/22-loggly.conf)
 * `node['loggly']['rsyslog']['host']` - Name of the remote loggly syslog host (defaults to logs-01.loggly.com)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,10 +10,9 @@ default['loggly']['tls']['cert_checksum'] = '20790d1a152b144bc7f4fc22f23efd582d9
 default['loggly']['tls']['intermediate_cert_url'] = 'https://certs.starfieldtech.com/repository/sf_bundle.crt'
 default['loggly']['tls']['intermediate_cert_checksum'] = '87d171b3333ca95a98aa02603fdb6508939c63f69e14c8587bd66c4f4df65032'
 
-default['loggly']['token']['from_databag'] = true
 default['loggly']['token']['databag'] = 'loggly'
 default['loggly']['token']['databag_item'] = 'token'
-default['loggly']['token']['value'] = '' # Will be set from Data Bag above by default
+default['loggly']['token']['value'] = nil
 
 default['loggly']['rsyslog']['conf'] = '/etc/rsyslog.d/22-loggly.conf'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,15 +7,14 @@
 # All rights reserved - Do Not Redistribute
 #
 
-if node['loggly']['token']['from_databag']
+if node['loggly']['token']['value']
+  loggly_token = node['loggly']['token']['value']
+else
   databag = node['loggly']['token']['databag']
   databag_item = node['loggly']['token']['databag_item']
 
   loggly_token = Chef::EncryptedDataBagItem.load(databag, databag_item)['token']
   raise "No token was found in databag item: #{databag}/#{databag_item}" if loggly_token.nil?
-else
-  raise "When not using a Data Bag, you have to define the Loggly token manually" if node['loggly']['token']['value'].empty?
-  loggly_token = node['loggly']['token']['value']
 end
 
 include_recipe "rsyslog::default"

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -44,13 +44,8 @@ describe 'loggly-rsyslog::default' do
   end
 
   context 'when the loggly token is set via an attribute' do
-    before do
-      Chef::EncryptedDataBagItem.stub(:load).with('loggly', 'token').and_return(nil)
-    end
-
     let(:chef_run) do
       ChefSpec::SoloRunner.new(CHEF_RUN_OPTIONS) do |node|
-        node.set['loggly']['token']['from_databag'] = false
         node.set['loggly']['token']['value'] = 'logglytoken1234'
       end.converge(described_recipe)
     end


### PR DESCRIPTION
Hi.  It seems the upstream cookbook is largely unmaintained and you now have the most up-to-date fork.  So I'm submitting this PR your way.

It drops the loggly.token.from_databag attr in favor of just checking whether loggly.token.value is set.  It probably seems like a trivial thing, but it actually bypasses a separate issue we encountered where AWS CloudFormation can't pass boolean json attrs to AWS OpsWorks stacks.  Given that this particular boolean attr isn't really necessary, this patch both makes the overall attrs cleaner and fixes our specific issue passing boolean chef attrs to OpsWorks.
