### PR TITLE
Bump dependency on rsyslog cookbook to 1.15.0.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ version          '2.1.0'
 supports 'ubuntu', '>= 12.04'
 
 depends "apt", "~> 2.0"
-depends "rsyslog", "~> 1.13.0"
+depends "rsyslog", "~> 1.15.0"


### PR DESCRIPTION
The rsyslog 1.15.0 cookbook is needed because 1.13.0 tries to set up systemd logging on Amazon Linux, a platform which doesn't actually use systemd.
